### PR TITLE
Fix typo in RegisterIdentity parameter description

### DIFF
--- a/internal/service/crypto.go
+++ b/internal/service/crypto.go
@@ -153,7 +153,7 @@ func (svc *CryptoService) RegisterIdentity(ctx *gin.Context) {
 //	@Description	Provides a way for clients to easily decrypt their encrypted message for which they have registered the identity for. Timestamp with which the identity was registered should have been passed for the message to be decrypted successfully.
 //	@Tags			Crypto
 //	@Produce		json
-//	@Param			identity			query		string		true	"Identity used for registeration and encrypting the message."
+//	@Param			identity			query		string		true	"Identity used for registration and encrypting the message."
 //	@Param			encryptedCommitment	query		string		true	"Encrypted commitment is the clients encrypted message."
 //	@Success		200					{object}	[]byte		"Success."
 //	@Failure		400					{object}	error.Http	"Invalid Decrypt commitment request."


### PR DESCRIPTION


Description:
This pull request corrects a minor typo in the documentation comment for the RegisterIdentity function parameter in internal/service/crypto.go. The word "registeration" has been fixed to "registration" for improved clarity and accuracy in the API documentation. No functional code changes were made.
