### PR TITLE
fix: avoid typed-nil panic in get_event_decryption_key handler

### DIFF
--- a/internal/service/crypto.go
+++ b/internal/service/crypto.go
@@ -83,9 +83,9 @@ func (svc *CryptoService) GetEventDecryptionKey(ctx *gin.Context) {
 			return
 		}
 	}
-	data, err := svc.CryptoUsecase.GetEventDecryptionKey(ctx, identity, eon)
-	if err != nil {
-		ctx.Error(err)
+	data, httpErr := svc.CryptoUsecase.GetEventDecryptionKey(ctx, identity, eon)
+	if httpErr != nil {
+		ctx.Error(httpErr)
 		return
 	}
 	ctx.JSON(http.StatusOK, gin.H{


### PR DESCRIPTION
err was already assigned the error interface, so assigning a nil HttpError made it non‑nil, therefore err != nil was true even when the underlying pointer was nil. That typed‑nil then hit the middleware and caused a nil‑pointer dereference.