### PR TITLE
Trim decryption key received from keyper http

### DIFF
--- a/internal/usecase/crypto.go
+++ b/internal/usecase/crypto.go
@@ -649,7 +649,7 @@ func (uc *CryptoUsecase) getDecryptionKeyFromExternalKeyper(ctx context.Context,
 		return "", errors.Wrapf(err, "failed to read keypers response body")
 	}
 
-	decryptionKey := string(body)
+	decryptionKey := strings.Trim(string(body), "\n\" ")
 
 	return decryptionKey, nil
 }

--- a/internal/usecase/crypto.go
+++ b/internal/usecase/crypto.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -625,7 +626,11 @@ func (uc *CryptoUsecase) DecryptCommitment(ctx context.Context, encryptedCommitm
 }
 
 func (uc *CryptoUsecase) getDecryptionKeyFromExternalKeyper(ctx context.Context, eon int64, identity string) (string, error) {
+
 	path := uc.config.KeyperHTTPURL.JoinPath("/decryptionKey/", fmt.Sprint(eon), "/", identity)
+	return QueryExternalKeyper(ctx, eon, identity, path)
+}
+func QueryExternalKeyper(ctx context.Context, eon int64, identity string, path *url.URL) (string, error) {
 
 	req, err := http.NewRequestWithContext(ctx, "GET", path.String(), http.NoBody)
 	if err != nil {

--- a/internal/usecase/crypto_test.go
+++ b/internal/usecase/crypto_test.go
@@ -1,0 +1,41 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+// Test to verify that QueryExternalKeyper correctly trims quotes and newlines from the response body.
+func TestGetDecryptionKeyFromExternalKeyper_QuotedBody(t *testing.T) {
+	expectedKey := "0xdeadbeefcaffee"
+
+	// Setup mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method
+		if r.Method != http.MethodGet {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+
+		w.Header().Set("Content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// this is how rolling-shutter http-api encodes the result
+		json.NewEncoder(w).Encode(expectedKey)
+	}))
+	defer server.Close()
+
+	parsedURL, _ := url.Parse(server.URL)
+
+	// Execute the function
+	ctx := context.Background()
+	result, err := QueryExternalKeyper(ctx, 1, "identity", parsedURL)
+
+	assert.NilError(t, err, "QueryExternalKeyper errored", err)
+	assert.Equal(t, result, expectedKey, "result not equal %v vs %v", result, expectedKey)
+}


### PR DESCRIPTION
The keyper http api at `/decryptionKey/` [encodes results as `"0x + <DECRYPTION_KEY_HEX>"` and serves them as `Content-type: application/json`](https://github.com/shutter-network/rolling-shutter/blob/main/rolling-shutter/keyper/kprapi/http.go#L65-L67). When receiving, we need to trim quotation and newlines, otherwise we will forward ill-formed results to our consumers, e.g.:

```
GET https://shutter-api.shutter.network/api/event/get_decryption_key?eon=13&identity=0xc744bee573e8f29e263c56fc0e46ef5f0b5ef3046da9c06bd2003164790c57e6

{"message":{"decryption_key":"\"0xb3c5f7a2e5bcbbda30602244b3a6d8ad361703b8990f1dcca58a4373099ca18b2ebb5e35196a17ba5f0b6969ae8530fb\"\n","identity":"0xc744bee573e8f29e263c56fc0e46ef5f0b5ef3046da9c06bd2003164790c57e6","decryption_timestamp":0}}
```